### PR TITLE
fs.rename should be synchronized

### DIFF
--- a/after-prepare-hook.js
+++ b/after-prepare-hook.js
@@ -72,7 +72,7 @@ var processFiles = function(dir,file,toKeep,toDelete,logger){
 	if(file.indexOf("." + toKeep + "." ) > -1){
 		try{
 			fs.unlinkSync(path.join(dir , file).replace("." + toKeep + ".","."))
-			fs.rename(path.join(dir , file),path.join(dir , file).replace("." + toKeep + ".","."), function(err) {
+			fs.renameSync(path.join(dir , file),path.join(dir , file).replace("." + toKeep + ".","."), function(err) {
 				if ( err ) logger.warn('ERROR: ' + err);
 			});
 		}catch(e){

--- a/after-prepare-hook.js
+++ b/after-prepare-hook.js
@@ -72,9 +72,7 @@ var processFiles = function(dir,file,toKeep,toDelete,logger){
 	if(file.indexOf("." + toKeep + "." ) > -1){
 		try{
 			fs.unlinkSync(path.join(dir , file).replace("." + toKeep + ".","."))
-			fs.renameSync(path.join(dir , file),path.join(dir , file).replace("." + toKeep + ".","."), function(err) {
-				if ( err ) logger.warn('ERROR: ' + err);
-			});
+			fs.renameSync(path.join(dir , file),path.join(dir , file).replace("." + toKeep + ".","."));
 		}catch(e){
 			logger.warn(e);
 		}


### PR DESCRIPTION
Hi, thanks for your helpful hook process.

I found if there is an `file.extension` file in `app/` folder, it may occurs the `file.extension` is missing at [line 60](https://github.com/markosko/nativescript-hook-debug-production/blob/master/after-prepare-hook.js#L60).

For example, there are three files in `app/` folder, including `app-config.ts`, `app-config.debug.ts` and `app-config.production.ts`. Once, the hook is invoked, it may occurs the following error.

```
{ Error: ENOENT: no such file or directory, stat '/my_app_project/platforms/android/src/main/assets/app/app-config.ts'
...
}
```

The error results from the asynchroized `fs.rename()` at [line 75](https://github.com/markosko/nativescript-hook-debug-production/blob/master/after-prepare-hook.js#L75). Since the `app-config.*.ts` is renaming into `app-config.ts`, the `app-config.ts` may be missing.